### PR TITLE
feat: Create basic `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Since this project also includes an `.envrc` using [`nix-direnv`](https://github
 for use with the provided flake, I strongly recommend setting up [`direnv`](https://direnv.net/)
 as well.
 
+Build depencies:
+ * [`docopt.c`](https://github.com/docopt/docopt.c): For generating the argument parser
+   in accordance with the [`docopt`](http://docopt.org/)-specification.
+
+   Meson needs to be able to find this in your Python's search-path.
+
 To build this project simply follow the usual `meson`-procedure:
 ```sh
 $ meson setuo build

--- a/README.md
+++ b/README.md
@@ -34,9 +34,14 @@ $ meson setuo build
 $ ninja -C build
 ```
 
+Afterwards, if everything went well, the executable can be found under `build/gnome-keyring-decryptor`.
+
 ## Usage
 
-TBD.
+To use this tool simply call `gnome-keyring-decryptor <keyring>` with `<keyring>`
+being the path to the keyring-file on the command line.
+
+The contents of the keyring will then be output on `stdout`.
 
 ## References
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,10 +16,34 @@
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};
     in {
+      docopt-c = pkgs.python311Packages.buildPythonPackage {
+        name = "docopt-c";
+
+        src = builtins.fetchGit {
+          url = "https://github.com/docopt/docopt.c.git";
+          ref = "master";
+          rev = "a8cdecfd6e6a15b19748222a2b9438a964bb3b58";
+        };
+
+        patchPhase = ''
+          substituteInPlace setup.py --replace \
+            "py_modules=[\"docopt_c\"]," \
+            "py_modules=[\"docopt_c\", \"docopt\"],"
+
+          substituteInPlace setup.py --replace \
+            "scripts=[\"docopt.py\", \"docopt_c.py\"]," \
+            "scripts=[\"docopt_c.py\"]," \
+        '';
+
+        pythonImportsCheck = ["docopt_c"];
+      };
+
       devShells.default = pkgs.mkShell {
         packages = [
           pkgs.meson
           pkgs.ninja
+          (pkgs.python311.withPackages
+            (ps: with ps; [self.docopt-c.${system}]))
         ];
       };
     });

--- a/meson.build
+++ b/meson.build
@@ -13,3 +13,12 @@ project(
 		'warning_level=3'
 	]
 )
+
+subdir('src')
+
+executable(
+	meson.project_name(),
+	link_with: main_lib,
+	cpp_args: '-DVERSION_STRING=' + meson.project_version(),
+	install: true
+)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,0 +1,13 @@
+/* Copyright 2023 Rufus Maurice Schäfing (wirklichniemand, nichtsundniemand)
+ *
+ * This file is part of `gnome-keyring-decryptor` and thus licensed under the terms
+ * of the GNU General Public License Version 3.
+ * A copy of this license can be found in the project's `LICENSE`-file.
+ */
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+static const char conf_version_string[] = "@version_string@";
+
+#endif

--- a/src/docopt.in
+++ b/src/docopt.in
@@ -1,0 +1,21 @@
+# Copyright 2023 Rufus Maurice Schäfing (wirklichniemand, nichtsundniemand)
+#
+# This file is part of `gnome-keyring-decryptor` and thus licensed under the terms
+# of the GNU General Public License Version 3.
+# A copy of this license can be found in the project's `LICENSE`-file.
+#
+Usage:
+  @exe_name@ <keyring>
+  @exe_name@ -h | --help
+  @exe_name@ --version
+
+Description:
+  This tool parses and decrypts a \"gnome-keyring\" keyring-file and dumps it's
+  contents as a JSON string.
+
+  The file to be decoded is passed on the command line through the <keyring>
+  parameter.
+
+Options:
+  -h --help   Show this help.
+  --version	  Show program version.

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,15 @@
+/* Copyright 2023 Rufus Maurice Schäfing (wirklichniemand, nichtsundniemand)
+ *
+ * This file is part of `gnome-keyring-decryptor` and thus licensed under the terms
+ * of the GNU General Public License Version 3.
+ * A copy of this license can be found in the project's `LICENSE`-file.
+ */
+
+#include <config.h>
+#include <docopt.h>
+
+int main(int argc, char *argv[]) {
+	docopt(argc, argv, true, conf_version_string);
+
+	return 0;
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,56 @@
+# Copyright 2023 Rufus Maurice Schäfing (wirklichniemand, nichtsundniemand)
+#
+# This file is part of `gnome-keyring-decryptor` and thus licensed under the terms
+# of the GNU General Public License Version 3.
+# A copy of this license can be found in the project's `LICENSE`-file.
+
+# Basically we only want to generate a meson-dependency for the docopt-parser.
+# This is simply done by calling the `docopt_c`-module with the config-file.
+#
+# The additional magic with `grep` and `configure_file()` is not really necessary,
+# but I wanted to have comments, which `docopt` does not support and to be able
+# to set the program's name dynamically...
+pymod = import('python')
+python_prog = pymod.find_installation(
+	'python3',
+	modules: ['docopt_c']
+)
+
+docopt_dep = declare_dependency(
+	sources: custom_target(
+		'docopt_generate',
+		input: custom_target(
+			'docopt_input_strip',
+			input: configure_file(
+				input: 'docopt.in',
+				output: 'docopt.configured',
+				configuration: {
+					'exe_name': meson.project_name()
+				}
+			),
+			output: 'main.docopt',
+			command: [find_program('grep'), '-v', '^#', '@INPUT@'],
+			capture: true
+		),
+		output: ['docopt.c', 'docopt.h'],
+		# This (specifically the part with `@OUTPUT0@`) only works, because `docopt_c` is kinda
+		# lax about the filename you pass with `-o`. Extensions are apparently stripped and then
+		# two files with `.c` and `.h` endings are created...
+		command: [python_prog, '-m', 'docopt_c', '@INPUT@', '-o', '@OUTPUT0@']
+	)
+)
+
+# Well, this is the place to put any build-time configuration/information, so use it :)
+config_header = configure_file(
+	input: 'config.h.in',
+	output: 'config.h',
+	configuration: {
+		'version_string': meson.project_version()
+	}
+)
+
+main_lib = static_library(
+	'main',
+	'main.c', config_header,
+	dependencies: [docopt_dep],
+)


### PR DESCRIPTION
This is the first step in creating the tool.

This first step comes with a CLI-parser, generated using `docopts`. This allows keeping the
definition of the CLI in a single file and makes for a more config-driven
approach, which I find pretty neat!

The rest is some scaffolding around that - mainly that complicated meson-setup
for codegen. This may be able to be improved.. I don't know. It's kinda ugly.