### PR TITLE
feat: Decode unencrypted part of the `.keyring` binary-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Build depencies:
    in accordance with the [`docopt`](http://docopt.org/)-specification.
 
    Meson needs to be able to find this in your Python's search-path.
+ * [`cmocka`](https://cmocka.org/): Test-framework used by the unit-tests.
+
+   This should be available through most distribution's repositories. Meson needs to
+   be able to find this as a dependency.
 
 To build this project simply follow the usual `meson`-procedure:
 ```sh

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Afterwards, if everything went well, the executable can be found under `build/gn
 
 ## Usage
 
-To use this tool simply call `gnome-keyring-decryptor <keyring>` with `<keyring>`
+To use this tool simply call `gnome-keyring-decryptor --keyring=<file>` with `<file>`
 being the path to the keyring-file on the command line.
 
 The contents of the keyring will then be output on `stdout`.

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,9 @@
 
       devShells.default = pkgs.mkShell {
         packages = [
+          pkgs.cmocka
           pkgs.ninja
+          pkgs.pkg-config
           (pkgs.python311.withPackages
             (ps: with ps; [
               self.docopt-c.${system}

--- a/lib/keyring/error.c
+++ b/lib/keyring/error.c
@@ -1,0 +1,191 @@
+/* Copyright 2023 Rufus Maurice Schäfing (wirklichniemand, nichtsundniemand)
+ *
+ * This file is part of `gnome-keyring-decryptor` and thus licensed under the terms
+ * of the GNU General Public License Version 3.
+ * A copy of this license can be found in the project's `LICENSE`-file.
+ */
+
+#include "error.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+struct error {
+	enum error_type type;
+	char *file;
+	char *function;
+	unsigned int line;
+	struct error *prev;
+	char *error_string;
+	char *(*format)(struct error *error);
+	void (*free)(struct error *error);
+};
+
+char *error_format(struct error *error) {
+	return error->format(error);
+}
+
+void error_free(struct error *error) {
+	if(error->prev != NULL) {
+		error_free(error->prev);
+		error->prev = NULL;
+	}
+
+	error->free(error);
+	free(error);
+}
+
+struct error_errno {
+	struct error base;
+	int number;
+};
+
+static char *error_errno_format_impl(struct error *error) {
+	if(error->type != ERROR_TYPE_ERRNO) {
+		return NULL;
+	}
+
+	struct error_errno *error_errno = (struct error_errno *)error;
+	error = NULL;
+
+	if(error_errno->base.error_string == NULL) {
+		error_errno->base.error_string = strerror(error_errno->number);
+	}
+
+	return error_errno->base.error_string;
+}
+
+static void error_errno_free_impl(struct error *error) {
+	// Nothing internal to free
+	(void)error;
+	return;
+}
+
+struct error *error_errno_new(const char *file, const char *function, const unsigned int line, struct error *prev, int number) {
+	struct error_errno *err = malloc(sizeof(struct error_errno));
+	*err = (struct error_errno){
+		.base = {
+			.type = ERROR_TYPE_ERRNO,
+			.file = file,
+			.function = function,
+			.line = line,
+			.prev = prev,
+			.error_string = NULL,
+			.format = error_errno_format_impl,
+			.free = error_errno_free_impl
+		},
+		.number = number
+	};
+
+	return (struct error *)err;
+}
+
+struct error_read {
+	struct error base;
+	enum error_read_type type;
+};
+
+static char *error_read_format_impl(struct error *error) {
+	if(error->type != ERROR_TYPE_READ) {
+		return NULL;
+	}
+
+	struct error_read *error_read = (struct error_read *)error;
+	error = NULL;
+
+	if(error_read->base.error_string == NULL) {
+		switch(error_read->type) {
+			case ERROR_READ_TYPE_CHILD_ERROR:
+				error_read->base.error_string = "child read failed";
+				break;
+			case ERROR_READ_TYPE_EOF:
+				error_read->base.error_string = "unexpected end of file";
+				break;
+		}
+	}
+
+	return error_read->base.error_string;
+}
+
+static void error_read_free_impl(struct error *error) {
+	// Nothing internal to free
+	(void)error;
+	return;
+}
+
+struct error *error_read_new(const char *file, const char *function, const unsigned int line, error_t prev, enum error_read_type type) {
+	struct error_read *err = malloc(sizeof(struct error_read));
+	*err = (struct error_read){
+		.base = {
+			.type = ERROR_TYPE_READ,
+			.file = file,
+			.function = function,
+			.line = line,
+			.prev = prev,
+			.error_string = NULL,
+			.format = error_read_format_impl,
+			.free = error_read_free_impl
+		},
+		.type = type
+	};
+
+	return (struct error *)err;
+}
+
+struct error_unmarshal {
+	struct error base;
+	enum error_unmarshal_type type;
+};
+
+static char *error_unmarshal_format_impl(struct error *error) {
+	if(error->type != ERROR_TYPE_UNMARSHAL) {
+		return NULL;
+	}
+
+	struct error_unmarshal *error_unmarshal = (struct error_unmarshal *)error;
+	error = NULL;
+
+	if(error_unmarshal->base.error_string == NULL) {
+		switch(error_unmarshal->type) {
+			case ERROR_UNMARSHAL_TYPE_READ_ERROR:
+				error_unmarshal->base.error_string = "failed to read value";
+				break;
+			case ERROR_UNMARSHAL_TYPE_CHILD_ERROR:
+				error_unmarshal->base.error_string = "failed to unmarshal child";
+				break;
+			case ERROR_UNMARSHAL_TYPE_SIGNATURE_MISMATCH:
+				error_unmarshal->base.error_string = "signature mismatch";
+				break;
+			case ERROR_UNMARSHAL_TYPE_INVALID_ATTRIBUTE_TYPE:
+				error_unmarshal->base.error_string = "invalid attribute_type";
+				break;
+		}
+	}
+
+	return error_unmarshal->base.error_string;
+}
+
+static void error_unmarshal_free_impl(struct error *error) {
+	// Nothing internal to free
+	(void)error;
+	return;
+}
+
+struct error *error_unmarshal_new(const char *file, const char *function, const unsigned int line, error_t prev, enum error_unmarshal_type type) {
+	struct error_unmarshal *err = malloc(sizeof(struct error_unmarshal));
+	*err = (struct error_unmarshal){
+		.base = {
+			.type = ERROR_TYPE_UNMARSHAL,
+			.file = file,
+			.function = function,
+			.line = line,
+			.prev = prev,
+			.error_string = NULL,
+			.format = error_unmarshal_format_impl,
+			.free = error_unmarshal_free_impl
+		},
+		.type = type
+	};
+
+	return (struct error *)err;
+}

--- a/lib/keyring/error.c
+++ b/lib/keyring/error.c
@@ -7,6 +7,7 @@
 
 #include "error.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -23,6 +24,12 @@ struct error {
 
 char *error_format(struct error *error) {
 	return error->format(error);
+}
+
+void error_trace(error_t error) {
+	for(error_t current = error; current != NULL; current = current->prev) {
+		fprintf(stderr, "%s: %s: %u\n\t%s\n", current->file, current->function, current->line, error_format(current));
+	}
 }
 
 void error_free(struct error *error) {

--- a/lib/keyring/error.h
+++ b/lib/keyring/error.h
@@ -19,6 +19,7 @@ struct error;
 typedef struct error *error_t;
 
 char *error_format(error_t err);
+void error_trace(error_t err);
 void error_free(error_t err);
 
 error_t error_errno_new(const char *file, const char *function, const unsigned int line, error_t prev, int number);

--- a/lib/keyring/error.h
+++ b/lib/keyring/error.h
@@ -1,0 +1,43 @@
+/* Copyright 2023 Rufus Maurice Schäfing (wirklichniemand, nichtsundniemand)
+ *
+ * This file is part of `gnome-keyring-decryptor` and thus licensed under the terms
+ * of the GNU General Public License Version 3.
+ * A copy of this license can be found in the project's `LICENSE`-file.
+ */
+
+#ifndef ERROR_H
+#define ERROR_H
+
+enum error_type {
+	ERROR_TYPE_NONE,
+	ERROR_TYPE_ERRNO,
+	ERROR_TYPE_READ,
+	ERROR_TYPE_UNMARSHAL
+};
+
+struct error;
+typedef struct error *error_t;
+
+char *error_format(error_t err);
+void error_free(error_t err);
+
+error_t error_errno_new(const char *file, const char *function, const unsigned int line, error_t prev, int number);
+#define error_errno_make(prev, number) error_errno_new(__FILE__, __func__, __LINE__, prev, number)
+
+enum error_read_type {
+	ERROR_READ_TYPE_CHILD_ERROR,
+	ERROR_READ_TYPE_EOF
+};
+error_t error_read_new(const char *file, const char *function, const unsigned int line, error_t prev, enum error_read_type type);
+#define error_read_make(prev, type) error_read_new(__FILE__, __func__, __LINE__, prev, type)
+
+enum error_unmarshal_type {
+	ERROR_UNMARSHAL_TYPE_READ_ERROR,
+	ERROR_UNMARSHAL_TYPE_CHILD_ERROR,
+	ERROR_UNMARSHAL_TYPE_SIGNATURE_MISMATCH,
+	ERROR_UNMARSHAL_TYPE_INVALID_ATTRIBUTE_TYPE
+};
+error_t error_unmarshal_new(const char *file, const char *function, const unsigned int line, error_t prev, enum error_unmarshal_type type);
+#define error_unmarshal_make(prev, type) error_unmarshal_new(__FILE__, __func__, __LINE__, prev, type)
+
+#endif

--- a/lib/keyring/internal/keyring.h
+++ b/lib/keyring/internal/keyring.h
@@ -1,0 +1,49 @@
+/* Copyright 2023 Rufus Maurice Schäfing (wirklichniemand, nichtsundniemand)
+ *
+ * This file is part of `gnome-keyring-decryptor` and thus licensed under the terms
+ * of the GNU General Public License Version 3.
+ * A copy of this license can be found in the project's `LICENSE`-file.
+ */
+
+#ifndef KEYRING_INTERNAL_H
+#define KEYRING_INTERNAL_H
+
+#include <stdint.h>
+
+uint8_t keystore_read_uint8(int fd, int *err);
+uint16_t keystore_read_uint16(int fd, int *err);
+uint32_t keystore_read_uint32(int fd, int *err);
+uint64_t keystore_read_uint64(int fd, int *err);
+void keystore_read_bytes(int fd, void *buf, uint32_t size, int *err);
+char *keystore_read_string(int fd, int *err);
+
+enum keystore_attribute_type {
+	KEYSTORE_ATTRIBUTE_TYPE_STRING,
+	KEYSTORE_ATTRIBUTE_TYPE_UINT32
+};
+
+struct keystore_attribute {
+	char *name;
+	enum keystore_attribute_type type;
+	union {
+		char *string;
+		uint32_t uint32;
+	} hash;
+};
+
+struct keystore_attribute keystore_attribute_unmarshal(int fd, int *err);
+void keystore_attribute_marshal(struct keystore_attribute *attribute);
+void keystore_attribute_free(struct keystore_attribute *attribute);
+
+struct keystore_keyring_item {
+	uint32_t id;
+	uint32_t type;
+	uint32_t num_attributes;
+	struct keystore_attribute *attributes;
+};
+
+struct keystore_keyring_item keystore_keyring_item_unmarshal(int fd, int *err);
+void keystore_keyring_item_marshal(struct keystore_keyring_item *item);
+void keystore_keyring_item_free(struct keystore_keyring_item *item);
+
+#endif

--- a/lib/keyring/internal/keyring.h
+++ b/lib/keyring/internal/keyring.h
@@ -10,12 +10,14 @@
 
 #include <stdint.h>
 
-uint8_t keystore_read_uint8(int fd, int *err);
-uint16_t keystore_read_uint16(int fd, int *err);
-uint32_t keystore_read_uint32(int fd, int *err);
-uint64_t keystore_read_uint64(int fd, int *err);
-void keystore_read_bytes(int fd, void *buf, uint32_t size, int *err);
-char *keystore_read_string(int fd, int *err);
+#include "../error.h"
+
+uint8_t keystore_read_uint8(int fd, error_t *err);
+uint16_t keystore_read_uint16(int fd, error_t *err);
+uint32_t keystore_read_uint32(int fd, error_t *err);
+uint64_t keystore_read_uint64(int fd, error_t *err);
+void keystore_read_bytes(int fd, void *buf, uint32_t size, error_t *err);
+char *keystore_read_string(int fd, error_t *err);
 
 enum keystore_attribute_type {
 	KEYSTORE_ATTRIBUTE_TYPE_STRING,
@@ -31,7 +33,7 @@ struct keystore_attribute {
 	} hash;
 };
 
-struct keystore_attribute keystore_attribute_unmarshal(int fd, int *err);
+struct keystore_attribute keystore_attribute_unmarshal(int fd, error_t *err);
 void keystore_attribute_marshal(struct keystore_attribute *attribute);
 void keystore_attribute_free(struct keystore_attribute *attribute);
 
@@ -42,7 +44,7 @@ struct keystore_keyring_item {
 	struct keystore_attribute *attributes;
 };
 
-struct keystore_keyring_item keystore_keyring_item_unmarshal(int fd, int *err);
+struct keystore_keyring_item keystore_keyring_item_unmarshal(int fd, error_t *err);
 void keystore_keyring_item_marshal(struct keystore_keyring_item *item);
 void keystore_keyring_item_free(struct keystore_keyring_item *item);
 

--- a/lib/keyring/keyring.c
+++ b/lib/keyring/keyring.c
@@ -1,0 +1,447 @@
+/* Copyright 2023 Rufus Maurice Schäfing (wirklichniemand, nichtsundniemand)
+ *
+ * This file is part of `gnome-keyring-decryptor` and thus licensed under the terms
+ * of the GNU General Public License Version 3.
+ * A copy of this license can be found in the project's `LICENSE`-file.
+ */
+
+#include "keyring.h"
+#include "internal/keyring.h"
+
+#include <endian.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+void keyring_version_marshal(struct keyring_version *version) {
+	if(version == NULL) {
+		return;
+	}
+
+	printf("\"version\":%hu,", version->version);
+	printf("\"crypto\":%hhu,", version->crypto);
+	printf("\"hash\":%hhu", version->hash);
+}
+
+void keystore_attribute_marshal(struct keystore_attribute *attribute) {
+	printf("\"%s\":{", attribute->name);
+	switch(attribute->type) {
+		case KEYSTORE_ATTRIBUTE_TYPE_STRING:
+			printf("\"type\":\"string\",");
+			// Maybe implement dumping the hash-value as base64?
+			printf("\"hash\":\"%s\"", attribute->hash.string);
+			break;
+		case KEYSTORE_ATTRIBUTE_TYPE_UINT32:
+			printf("\"type\":\"uint32\",");
+			printf("\"hash\":\"0x%08x\"", attribute->hash.uint32);
+			break;
+	}
+	printf("}");
+}
+
+void keystore_attribute_free(struct keystore_attribute *attribute) {
+	free(attribute->name);
+	attribute->name = NULL;
+
+	if(attribute->type == KEYSTORE_ATTRIBUTE_TYPE_STRING) {
+		free(attribute->hash.string);
+		attribute->hash.string = NULL;
+	}
+}
+
+void keystore_keyring_item_marshal(struct keystore_keyring_item *item) {
+	printf("\"id\":%u,", item->id);
+	printf("\"type\":%u,", item->type);
+	printf("\"attributes\":{");
+	for(uint32_t i = 0; i < item->num_attributes; i++) {
+		keystore_attribute_marshal(item->attributes + i);
+		printf("%s", (i + 1 < item->num_attributes)?",":"");
+	}
+	printf("}");
+}
+
+void keystore_keyring_item_free(struct keystore_keyring_item *item) {
+	for(uint32_t i = 0; i < item->num_attributes; i++) {
+		keystore_attribute_free(item->attributes + i);
+	}
+
+	free(item->attributes);
+	item->attributes = NULL;
+}
+
+void keyring_marshal(struct keyring *keyring) {
+	if(keyring == NULL) {
+		return;
+	}
+
+	printf("\"version:\":{");
+	keyring_version_marshal(&keyring->version);
+	printf("},");
+	printf("\"name\":");
+	if(keyring->name == NULL) {
+		printf("null");
+	} else {
+		printf("\"%s\"", keyring->name);
+	}
+	printf(",");
+	printf("\"ctime\":%lu,", keyring->ctime);
+	printf("\"mtime\":%lu,", keyring->mtime);
+	printf("\"flags\":%u,", keyring->flags);
+	printf("\"lock_timeout\":%u,", keyring->lock_timeout);
+	printf("\"hash_iterations\":%u,", keyring->hash_iterations);
+	printf("\"salt\":\"%p\",", keyring->salt);
+	printf("\"items\":[");
+	for(uint32_t i = 0; i < keyring->num_items; i++) {
+		printf("{");
+		keystore_keyring_item_marshal(keyring->items + i);
+		printf("}%s", (i + 1 < keyring->num_items)?",":"");
+	}
+	printf("]");
+}
+
+void keyring_free(struct keyring *keyring) {
+	free(keyring->name);
+	keyring->name = NULL;
+
+	for(uint32_t i = 0; i < keyring->num_items; i++) {
+		keystore_keyring_item_free(keyring->items + i);
+	}
+
+	free(keyring->items);
+	keyring->items = NULL;
+}
+
+uint8_t keystore_read_uint8(int fd, int *err) {
+	uint8_t value = 0;
+	ssize_t read_size = read(fd, &value, sizeof(value));
+
+	if(err == NULL) {
+		return value;
+	}
+
+	if(read_size == -1) {
+		*err = errno;
+	} else if(read_size != sizeof(uint8_t)) {
+		*err = 1;
+	} else {
+		*err = 0;
+	}
+
+	return value;
+}
+
+uint16_t keystore_read_uint16(int fd, int *err) {
+	uint16_t read_buf = 0;
+	ssize_t read_size = read(fd, &read_buf, sizeof(read_buf));
+
+	uint16_t value = be16toh(read_buf);
+
+	if(err == NULL) {
+		return value;
+	}
+
+	if(read_size == -1) {
+		*err = errno;
+	} else if(read_size != sizeof(uint16_t)) {
+		*err = 1;
+	} else {
+		*err = 0;
+	}
+
+	return value;
+}
+
+uint32_t keystore_read_uint32(int fd, int *err) {
+	uint32_t read_buf = 0;
+	ssize_t read_size = read(fd, &read_buf, sizeof(read_buf));
+
+	uint32_t value = be32toh(read_buf);
+
+	if(err == NULL) {
+		return value;
+	}
+
+	if(read_size == -1) {
+		*err = errno;
+	} else if(read_size != sizeof(uint32_t)) {
+		*err = 1;
+	} else {
+		*err = 0;
+	}
+
+	return value;
+}
+
+uint64_t keystore_read_uint64(int fd, int *err) {
+	uint64_t read_buf = 0;
+	ssize_t read_size = read(fd, &read_buf, sizeof(read_buf));
+
+	uint64_t value = be64toh(read_buf);
+
+	if(err == NULL) {
+		return value;
+	}
+
+	if(read_size == -1) {
+		*err = errno;
+	} else if(read_size != sizeof(uint64_t)) {
+		*err = 1;
+	} else {
+		*err = 0;
+	}
+
+	return value;
+}
+
+void keystore_read_bytes(int fd, void *buf, uint32_t size, int *err) {
+	ssize_t read_size = read(fd, buf, size);
+
+	if(err == NULL) {
+		return;
+	}
+
+	if(read_size == -1) {
+		*err = errno;
+	} else if(read_size != size) {
+		*err = 1;
+	} else {
+		*err = 0;
+	}
+}
+
+char *keystore_read_string(int fd, int *err) {
+	int size_err = 0;
+	uint32_t size = keystore_read_uint32(fd, &size_err);
+	if(size_err != 0) {
+		if(err != NULL) {
+			*err = size_err;
+		}
+
+		return NULL;
+	}
+
+	// Magic value for NULL-strings (see docs/file-format.txt)
+	if(size == 0xffffffff) {
+		*err = 0;
+		return NULL;
+	}
+
+	// keystore-strings are not null-terminated (see docs/file-format.txt)
+	char *string = malloc(size + 1);
+	int string_err = 0;
+	keystore_read_bytes(fd, string, size, &string_err);
+
+	if(string_err != 0) {
+		if(err != NULL) {
+			*err = string_err;
+		}
+
+		free(string);
+		return NULL;
+	}
+
+	string[size] = 0;
+
+	if(err != NULL) {
+		*err = 0;
+	}
+
+	return string;
+}
+
+struct keystore_attribute keystore_attribute_unmarshal(int fd, int *err) {
+	int local_err = 0;
+	struct keystore_attribute attribute = {0};
+
+	attribute.name = keystore_read_string(fd, &local_err);
+	if(local_err != 0) {
+		goto fail;
+	}
+
+	attribute.type = keystore_read_uint32(fd, &local_err);
+	if(local_err != 0) {
+		goto fail;
+	}
+
+	switch(attribute.type) {
+		case KEYSTORE_ATTRIBUTE_TYPE_STRING:
+			attribute.hash.string = keystore_read_string(fd, &local_err);
+			break;
+		case KEYSTORE_ATTRIBUTE_TYPE_UINT32:
+			attribute.hash.uint32 = keystore_read_uint32(fd, &local_err);
+			break;
+		default:
+			fprintf(
+				stderr, "Failed to parse attribute: Invalid attribute type (%u)\n",
+				attribute.type
+			);
+
+			local_err = 1;
+	}
+	if(local_err != 0) {
+		goto fail;
+	}
+
+	if(err != NULL) {
+		*err = 0;
+	}
+
+	return attribute;
+
+fail:
+	if(err != NULL) {
+		*err = local_err;
+	}
+
+	return (struct keystore_attribute){0};
+}
+
+struct keystore_keyring_item keystore_keyring_item_unmarshal(int fd, int *err) {
+	int local_err = 0;
+	struct keystore_keyring_item item = {0};
+
+	item.id = keystore_read_uint32(fd, &local_err);
+	if(local_err != 0) {
+		goto fail;
+	}
+
+	item.type = keystore_read_uint32(fd, &local_err);
+	if(local_err != 0) {
+		goto fail;
+	}
+
+	item.num_attributes = keystore_read_uint32(fd, &local_err);
+	if(local_err != 0) {
+		goto fail;
+	}
+
+	item.attributes = malloc(item.num_attributes * sizeof(struct keystore_attribute));
+	for(uint32_t i = 0; i < item.num_attributes; i++) {
+		item.attributes[i] = keystore_attribute_unmarshal(fd, &local_err);
+
+		if(local_err != 0) {
+			for(uint32_t j = 0; j < i; j++) {
+				keystore_attribute_free(item.attributes + j);
+			}
+			free(item.attributes);
+
+			goto fail;
+		}
+	}
+
+	return item;
+
+fail:
+	if(err != NULL) {
+		*err = local_err;
+	}
+
+	return (struct keystore_keyring_item){0};
+}
+
+struct keyring keyring_unmarshal(int fd, int *err) {
+	int local_err = 0;
+	struct keyring keyring = {0};
+
+	char signature[16] = {0};
+	keystore_read_bytes(fd, signature, 16, &local_err);
+	if(local_err != 0) {
+		goto fail;
+	}
+
+	if(memcmp("GnomeKeyring\n\r\0\n", signature, 16) != 0) {
+		local_err = 2;
+		goto fail;
+	}
+
+	keyring.version.version = keystore_read_uint16(fd, &local_err);
+	if(local_err != 0) {
+		goto fail;
+	}
+
+	keyring.version.crypto = keystore_read_uint8(fd, &local_err);
+	if(local_err != 0) {
+		goto fail;
+	}
+
+	keyring.version.hash = keystore_read_uint8(fd, &local_err);
+	if(local_err != 0) {
+		goto fail;
+	}
+
+	keyring.name = keystore_read_string(fd, &local_err);
+	if(local_err != 0) {
+		goto fail;
+	}
+
+	keyring.ctime = keystore_read_uint64(fd, &local_err);
+	if(local_err != 0) {
+		goto fail_name;
+	}
+
+	keyring.mtime = keystore_read_uint64(fd, &local_err);
+	if(local_err != 0) {
+		goto fail_name;
+	}
+
+	keyring.flags = keystore_read_uint32(fd, &local_err);
+	if(local_err != 0) {
+		goto fail_name;
+	}
+
+	keyring.lock_timeout = keystore_read_uint32(fd, &local_err);
+	if(local_err != 0) {
+		goto fail_name;
+	}
+
+	keyring.hash_iterations = keystore_read_uint32(fd, &local_err);
+	if(local_err != 0) {
+		goto fail_name;
+	}
+
+	keystore_read_bytes(fd, keyring.salt, 8, &local_err);
+	if(local_err != 0) {
+		goto fail_name;
+	}
+
+	// Skip reserved bytes
+	for(int i = 0; i < 4; i++) {
+		keystore_read_uint32(fd, &local_err);
+
+		if(local_err != 0) {
+			goto fail_name;
+		}
+	}
+
+	keyring.num_items = keystore_read_uint32(fd, &local_err);
+	if(local_err != 0) {
+		goto fail_name;
+	}
+
+	keyring.items = malloc(keyring.num_items * sizeof(struct keystore_keyring_item));
+	for(uint32_t i = 0; i < keyring.num_items; i++) {
+		keyring.items[i] = keystore_keyring_item_unmarshal(fd, &local_err);
+
+		if(local_err != 0) {
+			for(uint32_t j = 0; j < i; j++) {
+				keystore_keyring_item_free(keyring.items + j);
+			}
+			free(keyring.items);
+
+			goto fail_name;
+		}
+	}
+
+	return keyring;
+
+fail_name:
+	free(keyring.name);
+fail:
+	if(err != NULL) {
+		*err = local_err;
+	}
+
+	return (struct keyring){0};
+}

--- a/lib/keyring/keyring.h
+++ b/lib/keyring/keyring.h
@@ -10,6 +10,8 @@
 
 #include <stdint.h>
 
+#include "error.h"
+
 struct keyring_version {
 	uint16_t version;
 	uint8_t  crypto;
@@ -29,7 +31,7 @@ struct keyring {
 	struct keystore_keyring_item *items;
 };
 
-struct keyring keyring_unmarshal(int fd, int *err);
+struct keyring keyring_unmarshal(int fd, error_t *err);
 void keyring_marshal(struct keyring *keyring);
 void keyring_free(struct keyring *keyring);
 

--- a/lib/keyring/keyring.h
+++ b/lib/keyring/keyring.h
@@ -1,0 +1,36 @@
+/* Copyright 2023 Rufus Maurice Schäfing (wirklichniemand, nichtsundniemand)
+ *
+ * This file is part of `gnome-keyring-decryptor` and thus licensed under the terms
+ * of the GNU General Public License Version 3.
+ * A copy of this license can be found in the project's `LICENSE`-file.
+ */
+
+#ifndef KEYRING_H
+#define KEYRING_H
+
+#include <stdint.h>
+
+struct keyring_version {
+	uint16_t version;
+	uint8_t  crypto;
+	uint8_t  hash;
+};
+
+struct keyring {
+	struct keyring_version version;
+	char     *name;
+	uint64_t ctime;
+	uint64_t mtime;
+	uint32_t flags;
+	uint32_t lock_timeout;
+	uint32_t hash_iterations;
+	uint8_t  salt[8];
+	uint32_t num_items;
+	struct keystore_keyring_item *items;
+};
+
+struct keyring keyring_unmarshal(int fd, int *err);
+void keyring_marshal(struct keyring *keyring);
+void keyring_free(struct keyring *keyring);
+
+#endif

--- a/lib/keyring/meson.build
+++ b/lib/keyring/meson.build
@@ -9,3 +9,5 @@ keyring_lib = both_libraries(
 	'keyring.c',
 	c_args: '-D_DEFAULT_SOURCE'
 )
+
+subdir('test')

--- a/lib/keyring/meson.build
+++ b/lib/keyring/meson.build
@@ -4,22 +4,8 @@
 # of the GNU General Public License Version 3.
 # A copy of this license can be found in the project's `LICENSE`-file.
 
-project(
-	'gnome-keyring-decryptor',
-	'c',
-	version: '0.1',
-	default_options: [
-		'buildtype=release',
-		'c_std=c11',
-		'warning_level=3'
-	]
-)
-
-subdir('lib')
-subdir('src')
-
-executable(
-	meson.project_name(),
-	link_with: main_lib,
-	install: true
+keyring_lib = both_libraries(
+	'keyring',
+	'keyring.c',
+	c_args: '-D_DEFAULT_SOURCE'
 )

--- a/lib/keyring/meson.build
+++ b/lib/keyring/meson.build
@@ -6,7 +6,7 @@
 
 keyring_lib = both_libraries(
 	'keyring',
-	'keyring.c',
+	'keyring.c', 'error.c',
 	c_args: '-D_DEFAULT_SOURCE'
 )
 

--- a/lib/keyring/test/common.c
+++ b/lib/keyring/test/common.c
@@ -1,0 +1,37 @@
+/* Copyright 2023 Rufus Maurice Schäfing (wirklichniemand, nichtsundniemand)
+ *
+ * This file is part of `gnome-keyring-decryptor` and thus licensed under the terms
+ * of the GNU General Public License Version 3.
+ * A copy of this license can be found in the project's `LICENSE`-file.
+ */
+
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "common.h"
+
+int setup_no_input(void **state) {
+	struct no_input_state *test_state = test_malloc(sizeof(struct no_input_state));
+	assert_non_null(test_state);
+	*test_state = (struct no_input_state){
+		.empty_fd = memfd_create("", MFD_CLOEXEC),
+	};
+
+	assert_int_not_equal(-1, test_state->empty_fd);
+
+	*state = test_state;
+	return 0;
+}
+
+int teardown_no_input(void **state) {
+	assert_non_null(*state);
+	struct no_input_state *test_state = *state;
+
+	assert_int_not_equal(-1, test_state->empty_fd);
+	assert_int_equal(0, close(test_state->empty_fd));
+
+	test_free(test_state);
+	return 0;
+}

--- a/lib/keyring/test/common.h
+++ b/lib/keyring/test/common.h
@@ -1,0 +1,23 @@
+/* Copyright 2023 Rufus Maurice Schäfing (wirklichniemand, nichtsundniemand)
+ *
+ * This file is part of `gnome-keyring-decryptor` and thus licensed under the terms
+ * of the GNU General Public License Version 3.
+ * A copy of this license can be found in the project's `LICENSE`-file.
+ */
+
+#ifndef COMMON_H
+#define COMMON_H
+
+#include <stdlib.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <cmocka.h>
+
+struct no_input_state {
+	int empty_fd;
+};
+
+int setup_no_input(void **state);
+int teardown_no_input(void **state);
+
+#endif

--- a/lib/keyring/test/meson.build
+++ b/lib/keyring/test/meson.build
@@ -1,0 +1,24 @@
+# Copyright 2023 Rufus Maurice Schäfing (wirklichniemand, nichtsundniemand)
+#
+# This file is part of `gnome-keyring-decryptor` and thus licensed under the terms
+# of the GNU General Public License Version 3.
+# A copy of this license can be found in the project's `LICENSE`-file.
+
+test_cases = [
+	'read_test'
+]
+
+foreach test_case: test_cases
+	test(
+		test_case,
+		executable(
+			test_case,
+			test_case + '.c',
+			dependencies: dependency('cmocka'),
+			link_with: keyring_lib,
+			install: false
+		),
+		env: 'CMOCKA_MESSAGE_OUTPUT=TAP',
+		protocol: 'tap'
+	)
+endforeach

--- a/lib/keyring/test/meson.build
+++ b/lib/keyring/test/meson.build
@@ -13,7 +13,7 @@ foreach test_case: test_cases
 		test_case,
 		executable(
 			test_case,
-			test_case + '.c',
+			test_case + '.c', 'common.c',
 			dependencies: dependency('cmocka'),
 			link_with: keyring_lib,
 			install: false

--- a/lib/keyring/test/meson.build
+++ b/lib/keyring/test/meson.build
@@ -4,17 +4,20 @@
 # of the GNU General Public License Version 3.
 # A copy of this license can be found in the project's `LICENSE`-file.
 
+cmocka_dep = dependency('cmocka')
+
 test_cases = [
-	'read_test'
+	'read',
+	'unmarshal'
 ]
 
 foreach test_case: test_cases
 	test(
-		test_case,
+		test_case + '_test',
 		executable(
-			test_case,
-			test_case + '.c', 'common.c',
-			dependencies: dependency('cmocka'),
+			test_case + '_test',
+			test_case + '_test.c', 'common.c',
+			dependencies: cmocka_dep,
 			link_with: keyring_lib,
 			install: false
 		),

--- a/lib/keyring/test/read_test.c
+++ b/lib/keyring/test/read_test.c
@@ -1,0 +1,369 @@
+/* Copyright 2023 Rufus Maurice Schäfing (wirklichniemand, nichtsundniemand)
+ *
+ * This file is part of `gnome-keyring-decryptor` and thus licensed under the terms
+ * of the GNU General Public License Version 3.
+ * A copy of this license can be found in the project's `LICENSE`-file.
+ */
+
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <cmocka.h>
+
+#include "../internal/keyring.h"
+
+struct no_input_state {
+	int empty_fd;
+};
+
+int setup_no_input(void **state) {
+	struct no_input_state *test_state = test_malloc(sizeof(struct no_input_state));
+	assert_non_null(test_state);
+	*test_state = (struct no_input_state){
+		.empty_fd = memfd_create("", MFD_CLOEXEC),
+	};
+
+	assert_int_not_equal(-1, test_state->empty_fd);
+
+	*state = test_state;
+	return 0;
+}
+
+int teardown_no_input(void **state) {
+	assert_non_null(*state);
+	struct no_input_state *test_state = *state;
+
+	assert_int_not_equal(-1, test_state->empty_fd);
+	assert_int_equal(0, close(test_state->empty_fd));
+
+	test_free(test_state);
+	return 0;
+}
+
+struct read_uint_state {
+	uint64_t magic;
+	int full_fd;
+};
+
+int setup_read_uint(void **state) {
+	struct read_uint_state *test_state = test_malloc(sizeof(struct read_uint_state));
+	assert_non_null(test_state);
+	*test_state = (struct read_uint_state){
+		.magic = 0x4242424242424242,
+		.full_fd = memfd_create("", MFD_CLOEXEC)
+	};
+
+	assert_int_not_equal(-1, test_state->full_fd);
+	assert_int_equal(
+		sizeof(test_state->magic),
+		write(test_state->full_fd, &test_state->magic, sizeof(test_state->magic))
+	);
+	assert_int_equal(0, lseek(test_state->full_fd, 0, SEEK_SET));
+
+	*state = test_state;
+	return 0;
+}
+
+int teardown_read_uint(void **state) {
+	assert_non_null(*state);
+	struct read_uint_state *test_state = *state;
+
+	assert_int_not_equal(-1, test_state->full_fd);
+	assert_int_equal(0, close(test_state->full_fd));
+
+	test_free(test_state);
+	return 0;
+}
+
+struct read_bytes_state {
+	uint8_t bytes[4];
+	int byte_fd;
+};
+
+int setup_read_bytes(void **state) {
+	struct read_bytes_state *test_state = test_malloc(sizeof(struct read_bytes_state));
+	assert_non_null(test_state);
+	*test_state = (struct read_bytes_state){
+		.bytes = {0xDE, 0xAD, 0xBE, 0xEF},
+		.byte_fd = memfd_create("", MFD_CLOEXEC)
+	};
+
+	assert_int_not_equal(-1, test_state->byte_fd);
+	assert_int_equal(
+		sizeof(test_state->bytes),
+		write(test_state->byte_fd, test_state->bytes, sizeof(test_state->bytes))
+	);
+	assert_int_equal(0, lseek(test_state->byte_fd, 0, SEEK_SET));
+
+	*state = test_state;
+	return 0;
+}
+
+int teardown_read_bytes(void **state) {
+	assert_non_null(*state);
+	struct read_bytes_state *test_state = *state;
+
+	assert_int_not_equal(-1, test_state->byte_fd);
+	assert_int_equal(0, close(test_state->byte_fd));
+
+	test_free(test_state);
+	return 0;
+}
+
+struct read_string_state {
+	int null_string_fd;
+	int short_string_fd;
+	int proper_string_fd;
+	char proper_string[5];
+};
+
+int setup_read_string(void **state) {
+	struct read_string_state *test_state = test_malloc(sizeof(struct read_string_state));
+	assert_non_null(test_state);
+	*test_state = (struct read_string_state){
+		.null_string_fd = memfd_create("", MFD_CLOEXEC),
+		.short_string_fd = memfd_create("", MFD_CLOEXEC),
+		.proper_string_fd = memfd_create("", MFD_CLOEXEC),
+		.proper_string = "test"
+	};
+
+	assert_int_not_equal(-1, test_state->null_string_fd);
+	assert_int_not_equal(-1, test_state->short_string_fd);
+	assert_int_not_equal(-1, test_state->proper_string_fd);
+
+	static const uint32_t null_string_marker = 0xffffffff;
+	assert_int_equal(sizeof(null_string_marker), write(test_state->null_string_fd, &null_string_marker, sizeof(null_string_marker)));
+	assert_int_equal(0, lseek(test_state->null_string_fd, 0, SEEK_SET));
+
+	uint32_t short_string_size = htobe32(0x000000ff);
+	assert_int_equal(sizeof(short_string_size), write(test_state->short_string_fd, &short_string_size, sizeof(short_string_size)));
+	assert_int_equal(0, lseek(test_state->short_string_fd, 0, SEEK_SET));
+
+	uint32_t proper_string_size = htobe32(sizeof(test_state->proper_string) - 1);
+	assert_int_equal(sizeof(proper_string_size), write(test_state->proper_string_fd, &proper_string_size, sizeof(proper_string_size)));
+	assert_int_equal(
+		sizeof(test_state->proper_string) - 1,
+		write(test_state->proper_string_fd, test_state->proper_string, sizeof(test_state->proper_string) - 1)
+	);
+	assert_int_equal(0, lseek(test_state->proper_string_fd, 0, SEEK_SET));
+
+	*state = test_state;
+	return 0;
+}
+
+int teardown_read_string(void **state) {
+	assert_non_null(*state);
+	struct read_string_state *test_state = *state;
+
+	assert_int_not_equal(-1, test_state->null_string_fd);
+	assert_int_not_equal(-1, test_state->short_string_fd);
+	assert_int_not_equal(-1, test_state->proper_string_fd);
+
+	assert_int_equal(0, close(test_state->null_string_fd));
+	assert_int_equal(0, close(test_state->short_string_fd));
+	assert_int_equal(0, close(test_state->proper_string_fd));
+
+	test_free(test_state);
+	return 0;
+}
+
+void keystore_read_uint8_should_fail_on_invalid_fd() {
+	int err = 0;
+	keystore_read_uint8(-1, &err);
+	assert_int_not_equal(0, err);
+}
+
+void keystore_read_uint8_should_fail_on_no_input(void **state) {
+	struct no_input_state *test_state = *state;
+
+	int err = 0;
+	keystore_read_uint8(test_state->empty_fd, &err);
+	assert_int_not_equal(0, err);
+}
+
+void keystore_read_uint8_should_succeed_with_input(void **state) {
+	struct read_uint_state *test_state = *state;
+
+	int err = 0;
+	uint8_t value = keystore_read_uint8(test_state->full_fd, &err);
+	assert_int_equal(0, err);
+	assert_int_equal((uint8_t)test_state->magic, value);
+}
+
+void keystore_read_uint16_should_fail_on_invalid_fd() {
+	int err = 0;
+	keystore_read_uint16(-1, &err);
+	assert_int_not_equal(0, err);
+}
+
+void keystore_read_uint16_should_fail_on_no_input(void **state) {
+	struct no_input_state *test_state = *state;
+
+	int err = 0;
+	keystore_read_uint16(test_state->empty_fd, &err);
+	assert_int_not_equal(0, err);
+}
+
+void keystore_read_uint16_should_succeed_with_input(void **state) {
+	struct read_uint_state *test_state = *state;
+
+	int err = 0;
+	uint16_t value = keystore_read_uint16(test_state->full_fd, &err);
+	assert_int_equal(0, err);
+	assert_int_equal((uint16_t)test_state->magic, value);
+}
+
+void keystore_read_uint32_should_fail_on_invalid_fd() {
+	int err = 0;
+	keystore_read_uint32(-1, &err);
+	assert_int_not_equal(0, err);
+}
+
+void keystore_read_uint32_should_fail_on_no_input(void **state) {
+	struct no_input_state *test_state = *state;
+
+	int err = 0;
+	keystore_read_uint32(test_state->empty_fd, &err);
+	assert_int_not_equal(0, err);
+}
+
+void keystore_read_uint32_should_succeed_with_input(void **state) {
+	struct read_uint_state *test_state = *state;
+
+	int err = 0;
+	uint32_t value = keystore_read_uint32(test_state->full_fd, &err);
+	assert_int_equal(0, err);
+	assert_int_equal((uint32_t)test_state->magic, value);
+}
+
+void keystore_read_uint64_should_fail_on_invalid_fd() {
+	int err = 0;
+	keystore_read_uint64(-1, &err);
+	assert_int_not_equal(0, err);
+}
+
+void keystore_read_uint64_should_fail_on_no_input(void **state) {
+	struct no_input_state *test_state = *state;
+
+	int err = 0;
+	keystore_read_uint64(test_state->empty_fd, &err);
+	assert_int_not_equal(0, err);
+}
+
+void keystore_read_uint64_should_succeed_with_input(void **state) {
+	struct read_uint_state *test_state = *state;
+
+	int err = 0;
+	uint64_t value = keystore_read_uint64(test_state->full_fd, &err);
+	assert_int_equal(0, err);
+	assert_int_equal((uint64_t)test_state->magic, value);
+}
+
+void keystore_read_bytes_should_fail_on_invalid_fd() {
+	int err = 0;
+	uint8_t value[8] = {0};
+	keystore_read_bytes(-1, value, sizeof(value), &err);
+	assert_int_not_equal(0, err);
+}
+
+void keystore_read_bytes_should_fail_on_no_input(void **state) {
+	struct no_input_state *test_state = *state;
+
+	int err = 0;
+	uint8_t value[8] = {0};
+	keystore_read_bytes(test_state->empty_fd, value, sizeof(value), &err);
+	assert_int_not_equal(0, err);
+}
+
+void keystore_read_bytes_should_succeed_with_input(void **state) {
+	struct read_bytes_state *test_state = *state;
+
+	int err = 0;
+	uint8_t *value = test_malloc(sizeof(test_state->bytes));
+	keystore_read_bytes(test_state->byte_fd, value, sizeof(test_state->bytes), &err);
+	assert_int_equal(0, err);
+	assert_memory_equal(test_state->bytes, value, sizeof(test_state->bytes));
+
+	test_free(value);
+}
+
+void keystore_read_string_should_fail_on_invalid_fd() {
+	int err = 0;
+	char *value = keystore_read_string(-1, &err);
+	assert_int_not_equal(0, err);
+	assert_null(value);
+}
+
+void keystore_read_string_should_fail_on_no_input(void **state) {
+	struct no_input_state *test_state = *state;
+
+	int err = 0;
+	char *value = keystore_read_string(test_state->empty_fd, &err);
+	assert_int_not_equal(0, err);
+	assert_null(value);
+}
+
+void keystore_read_string_should_succeed_and_return_null_on_ffffffff(void **state) {
+	struct read_string_state *test_state = *state;
+
+	int err = 0;
+	char *value = keystore_read_string(test_state->null_string_fd, &err);
+	assert_int_equal(0, err);
+	assert_null(value);
+}
+
+void keystore_read_string_should_fail_on_input_too_short_for_size(void **state) {
+	struct read_string_state *test_state = *state;
+
+	int err = 0;
+	char *value = keystore_read_string(test_state->short_string_fd, &err);
+	assert_int_not_equal(0, err);
+	assert_null(value);
+}
+
+void keystore_read_string_should_succeed_and_return_string_on_proper_input(void **state) {
+	struct read_string_state *test_state = *state;
+
+	int err = 0;
+	char *value = keystore_read_string(test_state->proper_string_fd, &err);
+	assert_int_equal(0, err);
+	assert_string_equal(test_state->proper_string, value);
+
+	free(value);
+}
+
+int main() {
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(keystore_read_uint8_should_fail_on_invalid_fd),
+		cmocka_unit_test_setup_teardown(keystore_read_uint8_should_fail_on_no_input, setup_no_input, teardown_no_input),
+		cmocka_unit_test_setup_teardown(keystore_read_uint8_should_succeed_with_input, setup_read_uint, teardown_read_uint),
+
+		cmocka_unit_test(keystore_read_uint16_should_fail_on_invalid_fd),
+		cmocka_unit_test_setup_teardown(keystore_read_uint16_should_fail_on_no_input, setup_no_input, teardown_no_input),
+		cmocka_unit_test_setup_teardown(keystore_read_uint16_should_succeed_with_input, setup_read_uint, teardown_read_uint),
+
+		cmocka_unit_test(keystore_read_uint32_should_fail_on_invalid_fd),
+		cmocka_unit_test_setup_teardown(keystore_read_uint32_should_fail_on_no_input, setup_no_input, teardown_no_input),
+		cmocka_unit_test_setup_teardown(keystore_read_uint32_should_succeed_with_input, setup_read_uint, teardown_read_uint),
+
+		cmocka_unit_test(keystore_read_uint64_should_fail_on_invalid_fd),
+		cmocka_unit_test_setup_teardown(keystore_read_uint64_should_fail_on_no_input, setup_no_input, teardown_no_input),
+		cmocka_unit_test_setup_teardown(keystore_read_uint64_should_succeed_with_input, setup_read_uint, teardown_read_uint),
+
+		cmocka_unit_test(keystore_read_bytes_should_fail_on_invalid_fd),
+		cmocka_unit_test_setup_teardown(keystore_read_bytes_should_fail_on_no_input, setup_no_input, teardown_no_input),
+		cmocka_unit_test_setup_teardown(keystore_read_bytes_should_succeed_with_input, setup_read_bytes, teardown_read_bytes),
+
+		cmocka_unit_test(keystore_read_string_should_fail_on_invalid_fd),
+		cmocka_unit_test_setup_teardown(keystore_read_string_should_fail_on_no_input, setup_no_input, teardown_no_input),
+		cmocka_unit_test_setup_teardown(keystore_read_string_should_succeed_and_return_null_on_ffffffff, setup_read_string, teardown_read_string),
+		cmocka_unit_test_setup_teardown(keystore_read_string_should_fail_on_input_too_short_for_size, setup_read_string, teardown_read_string),
+		cmocka_unit_test_setup_teardown(keystore_read_string_should_succeed_and_return_string_on_proper_input, setup_read_string, teardown_read_string)
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/keyring/test/read_test.c
+++ b/lib/keyring/test/read_test.c
@@ -10,39 +10,8 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
-#include <setjmp.h>
-#include <stdarg.h>
-#include <cmocka.h>
-
+#include "common.h"
 #include "../internal/keyring.h"
-
-struct no_input_state {
-	int empty_fd;
-};
-
-int setup_no_input(void **state) {
-	struct no_input_state *test_state = test_malloc(sizeof(struct no_input_state));
-	assert_non_null(test_state);
-	*test_state = (struct no_input_state){
-		.empty_fd = memfd_create("", MFD_CLOEXEC),
-	};
-
-	assert_int_not_equal(-1, test_state->empty_fd);
-
-	*state = test_state;
-	return 0;
-}
-
-int teardown_no_input(void **state) {
-	assert_non_null(*state);
-	struct no_input_state *test_state = *state;
-
-	assert_int_not_equal(-1, test_state->empty_fd);
-	assert_int_equal(0, close(test_state->empty_fd));
-
-	test_free(test_state);
-	return 0;
-}
 
 struct read_uint_state {
 	uint64_t magic;

--- a/lib/keyring/test/read_test.c
+++ b/lib/keyring/test/read_test.c
@@ -141,165 +141,178 @@ int teardown_read_string(void **state) {
 }
 
 void keystore_read_uint8_should_fail_on_invalid_fd() {
-	int err = 0;
+	error_t err = 0;
 	keystore_read_uint8(-1, &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 }
 
 void keystore_read_uint8_should_fail_on_no_input(void **state) {
 	struct no_input_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	keystore_read_uint8(test_state->empty_fd, &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 }
 
 void keystore_read_uint8_should_succeed_with_input(void **state) {
 	struct read_uint_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	uint8_t value = keystore_read_uint8(test_state->full_fd, &err);
-	assert_int_equal(0, err);
+	assert_null(err);
 	assert_int_equal((uint8_t)test_state->magic, value);
 }
 
 void keystore_read_uint16_should_fail_on_invalid_fd() {
-	int err = 0;
+	error_t err = 0;
 	keystore_read_uint16(-1, &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 }
 
 void keystore_read_uint16_should_fail_on_no_input(void **state) {
 	struct no_input_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	keystore_read_uint16(test_state->empty_fd, &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 }
 
 void keystore_read_uint16_should_succeed_with_input(void **state) {
 	struct read_uint_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	uint16_t value = keystore_read_uint16(test_state->full_fd, &err);
-	assert_int_equal(0, err);
+	assert_null(err);
 	assert_int_equal((uint16_t)test_state->magic, value);
 }
 
 void keystore_read_uint32_should_fail_on_invalid_fd() {
-	int err = 0;
+	error_t err = 0;
 	keystore_read_uint32(-1, &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 }
 
 void keystore_read_uint32_should_fail_on_no_input(void **state) {
 	struct no_input_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	keystore_read_uint32(test_state->empty_fd, &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 }
 
 void keystore_read_uint32_should_succeed_with_input(void **state) {
 	struct read_uint_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	uint32_t value = keystore_read_uint32(test_state->full_fd, &err);
-	assert_int_equal(0, err);
+	assert_null(err);
 	assert_int_equal((uint32_t)test_state->magic, value);
 }
 
 void keystore_read_uint64_should_fail_on_invalid_fd() {
-	int err = 0;
+	error_t err = 0;
 	keystore_read_uint64(-1, &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 }
 
 void keystore_read_uint64_should_fail_on_no_input(void **state) {
 	struct no_input_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	keystore_read_uint64(test_state->empty_fd, &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 }
 
 void keystore_read_uint64_should_succeed_with_input(void **state) {
 	struct read_uint_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	uint64_t value = keystore_read_uint64(test_state->full_fd, &err);
-	assert_int_equal(0, err);
+	assert_null(err);
 	assert_int_equal((uint64_t)test_state->magic, value);
 }
 
 void keystore_read_bytes_should_fail_on_invalid_fd() {
-	int err = 0;
+	error_t err = 0;
 	uint8_t value[8] = {0};
 	keystore_read_bytes(-1, value, sizeof(value), &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 }
 
 void keystore_read_bytes_should_fail_on_no_input(void **state) {
 	struct no_input_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	uint8_t value[8] = {0};
 	keystore_read_bytes(test_state->empty_fd, value, sizeof(value), &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 }
 
 void keystore_read_bytes_should_succeed_with_input(void **state) {
 	struct read_bytes_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	uint8_t *value = test_malloc(sizeof(test_state->bytes));
 	keystore_read_bytes(test_state->byte_fd, value, sizeof(test_state->bytes), &err);
-	assert_int_equal(0, err);
+	assert_null(err);
 	assert_memory_equal(test_state->bytes, value, sizeof(test_state->bytes));
 
 	test_free(value);
 }
 
 void keystore_read_string_should_fail_on_invalid_fd() {
-	int err = 0;
+	error_t err = 0;
 	char *value = keystore_read_string(-1, &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 	assert_null(value);
 }
 
 void keystore_read_string_should_fail_on_no_input(void **state) {
 	struct no_input_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	char *value = keystore_read_string(test_state->empty_fd, &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 	assert_null(value);
 }
 
 void keystore_read_string_should_succeed_and_return_null_on_ffffffff(void **state) {
 	struct read_string_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	char *value = keystore_read_string(test_state->null_string_fd, &err);
-	assert_int_equal(0, err);
+	assert_null(err);
 	assert_null(value);
 }
 
 void keystore_read_string_should_fail_on_input_too_short_for_size(void **state) {
 	struct read_string_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	char *value = keystore_read_string(test_state->short_string_fd, &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 	assert_null(value);
 }
 
 void keystore_read_string_should_succeed_and_return_string_on_proper_input(void **state) {
 	struct read_string_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	char *value = keystore_read_string(test_state->proper_string_fd, &err);
-	assert_int_equal(0, err);
+	assert_null(err);
 	assert_string_equal(test_state->proper_string, value);
 
 	free(value);

--- a/lib/keyring/test/unmarshal_test.c
+++ b/lib/keyring/test/unmarshal_test.c
@@ -23,18 +23,20 @@ void assert_keystore_attribute_empty(struct keystore_attribute *attribute) {
 }
 
 void keystore_attribute_unmarshal_should_fail_on_invalid_fd() {
-	int err = 0;
+	error_t err = 0;
 	struct keystore_attribute value = keystore_attribute_unmarshal(-1, &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 	assert_keystore_attribute_empty(&value);
 }
 
 void keystore_attribute_unmarshal_should_fail_on_no_input(void **state) {
 	struct no_input_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	struct keystore_attribute value = keystore_attribute_unmarshal(test_state->empty_fd, &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 	assert_keystore_attribute_empty(&value);
 }
 
@@ -101,15 +103,15 @@ int teardown_proper_attribute(void **state) {
 void keystore_attribute_unmarshal_should_succeed_and_return_value_on_proper_input(void **state) {
 	struct proper_attribute_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	struct keystore_attribute string_attribute = keystore_attribute_unmarshal(test_state->string_fd, &err);
-	assert_int_equal(0, err);
+	assert_null(err);
 	assert_string_equal(test_state->string_attribute.name, string_attribute.name);
 	assert_int_equal(test_state->string_attribute.type, string_attribute.type);
 	assert_string_equal(test_state->string_attribute.hash.string, string_attribute.hash.string);
 
 	struct keystore_attribute uint32_attribute = keystore_attribute_unmarshal(test_state->uint32_fd, &err);
-	assert_int_equal(0, err);
+	assert_null(err);
 	assert_string_equal(test_state->uint32_attribute.name, uint32_attribute.name);
 	assert_int_equal(test_state->uint32_attribute.type, uint32_attribute.type);
 	assert_int_equal(test_state->uint32_attribute.hash.uint32, uint32_attribute.hash.uint32);
@@ -127,18 +129,20 @@ void assert_keystore_keyring_item_empty(struct keystore_keyring_item *item) {
 }
 
 void keystore_keyring_item_unmarshal_should_fail_on_invalid_fd() {
-	int err = 0;
+	error_t err = 0;
 	struct keystore_keyring_item value = keystore_keyring_item_unmarshal(-1, &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 	assert_keystore_keyring_item_empty(&value);
 }
 
 void keystore_keyring_item_unmarshal_should_fail_on_no_input(void **state) {
 	struct no_input_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	struct keystore_keyring_item value = keystore_keyring_item_unmarshal(test_state->empty_fd, &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 	assert_keystore_keyring_item_empty(&value);
 }
 
@@ -195,9 +199,9 @@ int teardown_proper_item(void **state) {
 void keystore_keyring_item_unmarshal_should_succeed_and_return_value_on_proper_input(void **state) {
 	struct proper_item_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	struct keystore_keyring_item value = keystore_keyring_item_unmarshal(test_state->fd, &err);
-	assert_int_equal(0, err);
+	assert_null(err);
 	assert_int_equal(test_state->item.id, value.id);
 	assert_int_equal(test_state->item.type, value.type);
 	assert_int_equal(test_state->item.num_attributes, value.num_attributes);
@@ -234,18 +238,20 @@ void assert_keyring_empty(struct keyring *keyring) {
 }
 
 void keyring_unmarshal_should_fail_on_invalid_fd() {
-	int err = 0;
+	error_t err = 0;
 	struct keyring value = keyring_unmarshal(-1, &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 	assert_keyring_empty(&value);
 }
 
 void keyring_unmarshal_should_fail_on_no_input(void **state) {
 	struct no_input_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	struct keyring value = keyring_unmarshal(test_state->empty_fd, &err);
-	assert_int_not_equal(0, err);
+	assert_non_null(err);
+	error_free(err);
 	assert_keyring_empty(&value);
 }
 
@@ -332,9 +338,9 @@ int teardown_proper_keyring(void **state) {
 void keyring_unmarshal_should_succeed_and_return_value_on_proper_input(void **state) {
 	struct proper_keyring_state *test_state = *state;
 
-	int err = 0;
+	error_t err = 0;
 	struct keyring value = keyring_unmarshal(test_state->fd, &err);
-	assert_int_equal(0, err);
+	assert_null(err);
 	assert_int_equal(test_state->keyring.version.version, value.version.version);
 	assert_int_equal(test_state->keyring.version.crypto, value.version.crypto);
 	assert_int_equal(test_state->keyring.version.hash, value.version.hash);

--- a/lib/keyring/test/unmarshal_test.c
+++ b/lib/keyring/test/unmarshal_test.c
@@ -26,6 +26,15 @@ void keystore_attribute_unmarshal_should_fail_on_invalid_fd() {
 	assert_keystore_attribute_empty(&value);
 }
 
+void keystore_attribute_unmarshal_should_fail_on_no_input(void **state) {
+	struct no_input_state *test_state = *state;
+
+	int err = 0;
+	struct keystore_attribute value = keystore_attribute_unmarshal(test_state->empty_fd, &err);
+	assert_int_not_equal(0, err);
+	assert_keystore_attribute_empty(&value);
+}
+
 void assert_keystore_keyring_item_empty(struct keystore_keyring_item *item) {
 	assert_non_null(item);
 	assert_int_equal(0, item->id);
@@ -37,6 +46,15 @@ void assert_keystore_keyring_item_empty(struct keystore_keyring_item *item) {
 void keystore_keyring_item_unmarshal_should_fail_on_invalid_fd() {
 	int err = 0;
 	struct keystore_keyring_item value = keystore_keyring_item_unmarshal(-1, &err);
+	assert_int_not_equal(0, err);
+	assert_keystore_keyring_item_empty(&value);
+}
+
+void keystore_keyring_item_unmarshal_should_fail_on_no_input(void **state) {
+	struct no_input_state *test_state = *state;
+
+	int err = 0;
+	struct keystore_keyring_item value = keystore_keyring_item_unmarshal(test_state->empty_fd, &err);
 	assert_int_not_equal(0, err);
 	assert_keystore_keyring_item_empty(&value);
 }
@@ -70,11 +88,23 @@ void keyring_unmarshal_should_fail_on_invalid_fd() {
 	assert_keyring_empty(&value);
 }
 
+void keyring_unmarshal_should_fail_on_no_input(void **state) {
+	struct no_input_state *test_state = *state;
+
+	int err = 0;
+	struct keyring value = keyring_unmarshal(test_state->empty_fd, &err);
+	assert_int_not_equal(0, err);
+	assert_keyring_empty(&value);
+}
+
 int main() {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test(keystore_attribute_unmarshal_should_fail_on_invalid_fd),
+		cmocka_unit_test_setup_teardown(keystore_attribute_unmarshal_should_fail_on_no_input, setup_no_input, teardown_no_input),
 		cmocka_unit_test(keystore_keyring_item_unmarshal_should_fail_on_invalid_fd),
-		cmocka_unit_test(keyring_unmarshal_should_fail_on_invalid_fd)
+		cmocka_unit_test_setup_teardown(keystore_keyring_item_unmarshal_should_fail_on_no_input, setup_no_input, teardown_no_input),
+		cmocka_unit_test(keyring_unmarshal_should_fail_on_invalid_fd),
+		cmocka_unit_test_setup_teardown(keyring_unmarshal_should_fail_on_no_input, setup_no_input, teardown_no_input)
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/lib/keyring/test/unmarshal_test.c
+++ b/lib/keyring/test/unmarshal_test.c
@@ -1,0 +1,81 @@
+/* Copyright 2023 Rufus Maurice Schäfing (wirklichniemand, nichtsundniemand)
+ *
+ * This file is part of `gnome-keyring-decryptor` and thus licensed under the terms
+ * of the GNU General Public License Version 3.
+ * A copy of this license can be found in the project's `LICENSE`-file.
+ */
+
+#include <stdlib.h>
+
+#include "common.h"
+#include "../keyring.h"
+#include "../internal/keyring.h"
+
+void assert_keystore_attribute_empty(struct keystore_attribute *attribute) {
+	assert_non_null(attribute);
+	assert_null(attribute->name);
+	assert_int_equal(0, attribute->type);
+	assert_null(attribute->hash.string);
+	assert_int_equal(0, attribute->hash.uint32);
+}
+
+void keystore_attribute_unmarshal_should_fail_on_invalid_fd() {
+	int err = 0;
+	struct keystore_attribute value = keystore_attribute_unmarshal(-1, &err);
+	assert_int_not_equal(0, err);
+	assert_keystore_attribute_empty(&value);
+}
+
+void assert_keystore_keyring_item_empty(struct keystore_keyring_item *item) {
+	assert_non_null(item);
+	assert_int_equal(0, item->id);
+	assert_int_equal(0, item->type);
+	assert_int_equal(0, item->num_attributes);
+	assert_null(item->attributes);
+}
+
+void keystore_keyring_item_unmarshal_should_fail_on_invalid_fd() {
+	int err = 0;
+	struct keystore_keyring_item value = keystore_keyring_item_unmarshal(-1, &err);
+	assert_int_not_equal(0, err);
+	assert_keystore_keyring_item_empty(&value);
+}
+
+void assert_keyring_version_empty(struct keyring_version *version) {
+	assert_non_null(version);
+	assert_int_equal(0, version->version);
+	assert_int_equal(0, version->crypto);
+	assert_int_equal(0, version->hash);
+}
+
+void assert_keyring_empty(struct keyring *keyring) {
+	assert_non_null(keyring);
+	assert_keyring_version_empty(&keyring->version);
+	assert_null(keyring->name);
+	assert_int_equal(0, keyring->ctime);
+	assert_int_equal(0, keyring->mtime);
+	assert_int_equal(0, keyring->flags);
+	assert_int_equal(0, keyring->lock_timeout);
+	assert_int_equal(0, keyring->hash_iterations);
+	uint8_t empty_salt[8] = {0};
+	assert_memory_equal(empty_salt, keyring->salt, sizeof(empty_salt));
+	assert_int_equal(0, keyring->num_items);
+	assert_null(keyring->items);
+}
+
+void keyring_unmarshal_should_fail_on_invalid_fd() {
+	int err = 0;
+	struct keyring value = keyring_unmarshal(-1, &err);
+	assert_int_not_equal(0, err);
+	assert_keyring_empty(&value);
+}
+
+int main() {
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(keystore_attribute_unmarshal_should_fail_on_invalid_fd),
+		cmocka_unit_test(keystore_keyring_item_unmarshal_should_fail_on_invalid_fd),
+		cmocka_unit_test(keyring_unmarshal_should_fail_on_invalid_fd)
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/keyring/test/unmarshal_test.c
+++ b/lib/keyring/test/unmarshal_test.c
@@ -5,7 +5,10 @@
  * A copy of this license can be found in the project's `LICENSE`-file.
  */
 
+#define _GNU_SOURCE
 #include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
 
 #include "common.h"
 #include "../keyring.h"
@@ -35,6 +38,86 @@ void keystore_attribute_unmarshal_should_fail_on_no_input(void **state) {
 	assert_keystore_attribute_empty(&value);
 }
 
+struct proper_attribute_state {
+	struct keystore_attribute string_attribute;
+	struct keystore_attribute uint32_attribute;
+	int string_fd;
+	int uint32_fd;
+};
+
+int setup_proper_attribute(void **state) {
+	struct proper_attribute_state *test_state = test_malloc(sizeof(struct proper_attribute_state));
+	*test_state = (struct proper_attribute_state){
+		.string_attribute = {
+			.name = "string_attribute",
+			.type = KEYSTORE_ATTRIBUTE_TYPE_STRING,
+			.hash.string = "string_value"
+		},
+		.uint32_attribute = {
+			.name = "uint32_attribute",
+			.type = KEYSTORE_ATTRIBUTE_TYPE_UINT32,
+			.hash.uint32 = 42
+		},
+		.string_fd = memfd_create("", MFD_CLOEXEC),
+		.uint32_fd = memfd_create("", MFD_CLOEXEC)
+	};
+
+	assert_int_not_equal(-1, test_state->string_fd);
+	assert_int_not_equal(-1, test_state->uint32_fd);
+
+	char string_attribute_buf[] = "\x00\x00\x00\x10"
+	                              "string_attribute"
+	                              "\x00\x00\x00\x00"
+	                              "\x00\x00\x00\x0C"
+	                              "string_value";
+	assert_int_equal(sizeof(string_attribute_buf) - 1, write(test_state->string_fd, string_attribute_buf, sizeof(string_attribute_buf) - 1));
+	assert_int_equal(0, lseek(test_state->string_fd, 0, SEEK_SET));
+
+	char uint32_attribute_buf[] = "\x00\x00\x00\x10"
+	                              "uint32_attribute"
+	                              "\x00\x00\x00\x01"
+	                              "\x00\x00\x00\x2A";
+	assert_int_equal(sizeof(uint32_attribute_buf) - 1, write(test_state->uint32_fd, uint32_attribute_buf, sizeof(uint32_attribute_buf) - 1));
+	assert_int_equal(0, lseek(test_state->uint32_fd, 0, SEEK_SET));
+
+	*state = test_state;
+	return 0;
+}
+
+int teardown_proper_attribute(void **state) {
+	assert_non_null(*state);
+	struct proper_attribute_state *test_state = *state;
+
+	assert_int_not_equal(-1, test_state->string_fd);
+	assert_int_not_equal(-1, test_state->uint32_fd);
+
+	assert_int_equal(0, close(test_state->string_fd));
+	assert_int_equal(0, close(test_state->uint32_fd));
+
+	test_free(test_state);
+	return 0;
+}
+
+void keystore_attribute_unmarshal_should_succeed_and_return_value_on_proper_input(void **state) {
+	struct proper_attribute_state *test_state = *state;
+
+	int err = 0;
+	struct keystore_attribute string_attribute = keystore_attribute_unmarshal(test_state->string_fd, &err);
+	assert_int_equal(0, err);
+	assert_string_equal(test_state->string_attribute.name, string_attribute.name);
+	assert_int_equal(test_state->string_attribute.type, string_attribute.type);
+	assert_string_equal(test_state->string_attribute.hash.string, string_attribute.hash.string);
+
+	struct keystore_attribute uint32_attribute = keystore_attribute_unmarshal(test_state->uint32_fd, &err);
+	assert_int_equal(0, err);
+	assert_string_equal(test_state->uint32_attribute.name, uint32_attribute.name);
+	assert_int_equal(test_state->uint32_attribute.type, uint32_attribute.type);
+	assert_int_equal(test_state->uint32_attribute.hash.uint32, uint32_attribute.hash.uint32);
+
+	keystore_attribute_free(&string_attribute);
+	keystore_attribute_free(&uint32_attribute);
+}
+
 void assert_keystore_keyring_item_empty(struct keystore_keyring_item *item) {
 	assert_non_null(item);
 	assert_int_equal(0, item->id);
@@ -57,6 +140,75 @@ void keystore_keyring_item_unmarshal_should_fail_on_no_input(void **state) {
 	struct keystore_keyring_item value = keystore_keyring_item_unmarshal(test_state->empty_fd, &err);
 	assert_int_not_equal(0, err);
 	assert_keystore_keyring_item_empty(&value);
+}
+
+struct proper_item_state {
+	struct keystore_attribute attribute;
+	struct keystore_keyring_item item;
+	int fd;
+};
+
+int setup_proper_item(void **state) {
+	struct proper_item_state *test_state = test_malloc(sizeof(struct proper_item_state));
+	*test_state = (struct proper_item_state){
+		.attribute = {
+			.name = "uint32_attribute",
+			.type = KEYSTORE_ATTRIBUTE_TYPE_UINT32,
+			.hash.uint32 = 42
+		},
+		.item = {
+			.id = 42,
+			.type = 42,
+			.num_attributes = 1,
+			.attributes = &test_state->attribute
+		},
+		.fd = memfd_create("", MFD_CLOEXEC)
+	};
+
+	assert_int_not_equal(-1, test_state->fd);
+
+	char item_buf[] = "\x00\x00\x00\x2A"
+	                  "\x00\x00\x00\x2A"
+	                  "\x00\x00\x00\x01"
+	                  "\x00\x00\x00\x10"
+	                  "uint32_attribute"
+	                  "\x00\x00\x00\x01"
+	                  "\x00\x00\x00\x2A";
+	assert_int_equal(sizeof(item_buf) - 1, write(test_state->fd, item_buf, sizeof(item_buf) - 1));
+	assert_int_equal(0, lseek(test_state->fd, 0, SEEK_SET));
+
+	*state = test_state;
+	return 0;
+}
+
+int teardown_proper_item(void **state) {
+	assert_non_null(*state);
+	struct proper_item_state *test_state = *state;
+
+	assert_int_not_equal(-1, test_state->fd);
+	assert_int_equal(0, close(test_state->fd));
+
+	test_free(test_state);
+	return 0;
+}
+
+void keystore_keyring_item_unmarshal_should_succeed_and_return_value_on_proper_input(void **state) {
+	struct proper_item_state *test_state = *state;
+
+	int err = 0;
+	struct keystore_keyring_item value = keystore_keyring_item_unmarshal(test_state->fd, &err);
+	assert_int_equal(0, err);
+	assert_int_equal(test_state->item.id, value.id);
+	assert_int_equal(test_state->item.type, value.type);
+	assert_int_equal(test_state->item.num_attributes, value.num_attributes);
+
+	for(uint32_t i = 0; i < test_state->item.num_attributes; i++) {
+		assert_string_equal(test_state->item.attributes[i].name, value.attributes[i].name);
+		assert_int_equal(test_state->item.attributes[i].type, value.attributes[i].type);
+		assert_int_equal(test_state->item.attributes[i].hash.uint32, value.attributes[i].hash.uint32);
+	}
+
+	keystore_keyring_item_free(&value);
 }
 
 void assert_keyring_version_empty(struct keyring_version *version) {
@@ -97,14 +249,130 @@ void keyring_unmarshal_should_fail_on_no_input(void **state) {
 	assert_keyring_empty(&value);
 }
 
+struct proper_keyring_state {
+	struct keystore_attribute attribute;
+	struct keystore_keyring_item item;
+	struct keyring keyring;
+	int fd;
+};
+
+int setup_proper_keyring(void **state) {
+	struct proper_keyring_state *test_state = test_malloc(sizeof(struct proper_keyring_state));
+	*test_state = (struct proper_keyring_state){
+		.attribute = {
+			.name = "uint32_attribute",
+			.type = KEYSTORE_ATTRIBUTE_TYPE_UINT32,
+			.hash.uint32 = 42
+		},
+		.item = {
+			.id = 42,
+			.type = 42,
+			.num_attributes = 1,
+			.attributes = &test_state->attribute
+		},
+		.keyring = {
+			.version.version = 1,
+			.version.crypto = 1,
+			.version.hash = 1,
+			.name = "keyring",
+			.ctime = 1,
+			.mtime = 1,
+			.flags = 1,
+			.lock_timeout = 1,
+			.hash_iterations = 1,
+			.salt = {0, 1, 2, 3, 4, 5, 6, 7},
+			.num_items = 1,
+			.items = &test_state->item
+		},
+		.fd = memfd_create("", MFD_CLOEXEC)
+	};
+
+	assert_int_not_equal(-1, test_state->fd);
+
+	char keyring_buf[] = "GnomeKeyring\n\r\0\n"
+	                     "\x00\x01\x01\x01"
+	                     "\x00\x00\x00\x07"
+	                     "keyring"
+	                     "\x00\x00\x00\x00\x00\x00\x00\x01"
+	                     "\x00\x00\x00\x00\x00\x00\x00\x01"
+	                     "\x00\x00\x00\x01"
+	                     "\x00\x00\x00\x01"
+	                     "\x00\x00\x00\x01"
+	                     "\x00\x01\x02\x03\x04\x05\x06\x07"
+	                     "\x00\x00\x00\x00"
+	                     "\x00\x00\x00\x00"
+	                     "\x00\x00\x00\x00"
+	                     "\x00\x00\x00\x00"
+	                     "\x00\x00\x00\x01"
+	                     "\x00\x00\x00\x2A"
+	                     "\x00\x00\x00\x2A"
+	                     "\x00\x00\x00\x01"
+	                     "\x00\x00\x00\x10"
+	                     "uint32_attribute"
+	                     "\x00\x00\x00\x01"
+	                     "\x00\x00\x00\x2A";
+	assert_int_equal(sizeof(keyring_buf) - 1, write(test_state->fd, keyring_buf, sizeof(keyring_buf) - 1));
+	assert_int_equal(0, lseek(test_state->fd, 0, SEEK_SET));
+
+	*state = test_state;
+	return 0;
+}
+
+int teardown_proper_keyring(void **state) {
+	assert_non_null(*state);
+	struct proper_keyring_state *test_state = *state;
+
+	assert_int_not_equal(-1, test_state->fd);
+	assert_int_equal(0, close(test_state->fd));
+
+	test_free(test_state);
+	return 0;
+}
+
+void keyring_unmarshal_should_succeed_and_return_value_on_proper_input(void **state) {
+	struct proper_keyring_state *test_state = *state;
+
+	int err = 0;
+	struct keyring value = keyring_unmarshal(test_state->fd, &err);
+	assert_int_equal(0, err);
+	assert_int_equal(test_state->keyring.version.version, value.version.version);
+	assert_int_equal(test_state->keyring.version.crypto, value.version.crypto);
+	assert_int_equal(test_state->keyring.version.hash, value.version.hash);
+	assert_string_equal(test_state->keyring.name, value.name);
+	assert_int_equal(test_state->keyring.ctime, value.ctime);
+	assert_int_equal(test_state->keyring.mtime, value.mtime);
+	assert_int_equal(test_state->keyring.flags, value.flags);
+	assert_int_equal(test_state->keyring.lock_timeout, value.lock_timeout);
+	assert_int_equal(test_state->keyring.hash_iterations, value.hash_iterations);
+	assert_memory_equal(test_state->keyring.salt, value.salt, sizeof(test_state->keyring.salt));
+	assert_int_equal(test_state->keyring.num_items, value.num_items);
+
+	for(uint32_t i = 0; i < test_state->keyring.num_items; i++) {
+		assert_int_equal(test_state->keyring.items[i].id, value.items[i].id);
+		assert_int_equal(test_state->keyring.items[i].type, value.items[i].type);
+		assert_int_equal(test_state->keyring.items[i].num_attributes, value.items[i].num_attributes);
+
+		for(uint32_t j = 0; j < test_state->keyring.items[i].num_attributes; j++) {
+			assert_string_equal(test_state->keyring.items[i].attributes[j].name, value.items[i].attributes[j].name);
+			assert_int_equal(test_state->keyring.items[i].attributes[j].type, value.items[i].attributes[j].type);
+			assert_int_equal(test_state->keyring.items[i].attributes[j].hash.uint32, value.items[i].attributes[j].hash.uint32);
+		}
+	}
+
+	keyring_free(&value);
+}
+
 int main() {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test(keystore_attribute_unmarshal_should_fail_on_invalid_fd),
 		cmocka_unit_test_setup_teardown(keystore_attribute_unmarshal_should_fail_on_no_input, setup_no_input, teardown_no_input),
+		cmocka_unit_test_setup_teardown(keystore_attribute_unmarshal_should_succeed_and_return_value_on_proper_input, setup_proper_attribute, teardown_proper_attribute),
 		cmocka_unit_test(keystore_keyring_item_unmarshal_should_fail_on_invalid_fd),
 		cmocka_unit_test_setup_teardown(keystore_keyring_item_unmarshal_should_fail_on_no_input, setup_no_input, teardown_no_input),
+		cmocka_unit_test_setup_teardown(keystore_keyring_item_unmarshal_should_succeed_and_return_value_on_proper_input, setup_proper_item, teardown_proper_item),
 		cmocka_unit_test(keyring_unmarshal_should_fail_on_invalid_fd),
-		cmocka_unit_test_setup_teardown(keyring_unmarshal_should_fail_on_no_input, setup_no_input, teardown_no_input)
+		cmocka_unit_test_setup_teardown(keyring_unmarshal_should_fail_on_no_input, setup_no_input, teardown_no_input),
+		cmocka_unit_test_setup_teardown(keyring_unmarshal_should_succeed_and_return_value_on_proper_input, setup_proper_keyring, teardown_proper_keyring),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -4,22 +4,9 @@
 # of the GNU General Public License Version 3.
 # A copy of this license can be found in the project's `LICENSE`-file.
 
-project(
-	'gnome-keyring-decryptor',
-	'c',
-	version: '0.1',
-	default_options: [
-		'buildtype=release',
-		'c_std=c11',
-		'warning_level=3'
-	]
-)
+subdir('keyring')
 
-subdir('lib')
-subdir('src')
-
-executable(
-	meson.project_name(),
-	link_with: main_lib,
-	install: true
+keyring_dep = declare_dependency(
+	link_with: keyring_lib,
+	include_directories: '.'
 )

--- a/src/docopt.in
+++ b/src/docopt.in
@@ -5,7 +5,7 @@
 # A copy of this license can be found in the project's `LICENSE`-file.
 #
 Usage:
-  @exe_name@ <keyring>
+  @exe_name@ --keyring=<keyring>
   @exe_name@ -h | --help
   @exe_name@ --version
 
@@ -13,9 +13,7 @@ Description:
   This tool parses and decrypts a \"gnome-keyring\" keyring-file and dumps it's
   contents as a JSON string.
 
-  The file to be decoded is passed on the command line through the <keyring>
-  parameter.
-
 Options:
-  -h --help   Show this help.
-  --version	  Show program version.
+  --keyring=<keyring> Keyring file to be decoded
+  -h --help           Show this help.
+  --version           Show program version.

--- a/src/main.c
+++ b/src/main.c
@@ -25,29 +25,13 @@ int main(int argc, char *argv[]) {
 		return 1;
 	}
 
-	int err = 0;
+	error_t err = NULL;
 	struct keyring keyring = keyring_unmarshal(fd, &err);
 
-	if(err < 0) {
-		fprintf(stderr, "Failed to unmarshal \"%s\": %s\n", args.keyring, strerror(err));
+	if(err != NULL) {
+		fprintf(stderr, "Failed to unmarshal \"%s\": %s\n", args.keyring, error_format(err));
 
-		close(fd);
-		return 1;
-	}
-
-	if(err > 0) {
-		char *err_str = NULL;
-		switch(err) {
-			case 1:
-				err_str = "Not enough bytes in input";
-				break;
-			case 2:
-				err_str = "Signature mismatch\n";
-				break;
-		}
-
-		fprintf(stderr, "Failed to unmarshal \"%s\": %s\n", args.keyring, err_str);
-
+		error_free(err);
 		close(fd);
 		return 1;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -5,11 +5,58 @@
  * A copy of this license can be found in the project's `LICENSE`-file.
  */
 
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
 #include <config.h>
 #include <docopt.h>
+#include <keyring/keyring.h>
 
 int main(int argc, char *argv[]) {
-	docopt(argc, argv, true, conf_version_string);
+	struct DocoptArgs args = docopt(argc, argv, true, conf_version_string);
 
+	int fd;
+	if((fd = open(args.keyring, O_RDONLY)) == -1) {
+		fprintf(stderr, "Could not open \"%s\": %s\n", args.keyring, strerror(errno));
+
+		return 1;
+	}
+
+	int err = 0;
+	struct keyring keyring = keyring_unmarshal(fd, &err);
+
+	if(err < 0) {
+		fprintf(stderr, "Failed to unmarshal \"%s\": %s\n", args.keyring, strerror(err));
+
+		close(fd);
+		return 1;
+	}
+
+	if(err > 0) {
+		char *err_str = NULL;
+		switch(err) {
+			case 1:
+				err_str = "Not enough bytes in input";
+				break;
+			case 2:
+				err_str = "Signature mismatch\n";
+				break;
+		}
+
+		fprintf(stderr, "Failed to unmarshal \"%s\": %s\n", args.keyring, err_str);
+
+		close(fd);
+		return 1;
+	}
+
+	printf("{");
+	keyring_marshal(&keyring);
+	printf("}\n");
+
+	keyring_free(&keyring);
+	close(fd);
 	return 0;
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -52,5 +52,5 @@ config_header = configure_file(
 main_lib = static_library(
 	'main',
 	'main.c', config_header,
-	dependencies: [docopt_dep],
+	dependencies: [docopt_dep, keyring_dep]
 )


### PR DESCRIPTION
This is basically half the work!
This patch introduces a lot of the data-structures and logic necessary for parsing a keyring-file.

It also already includes a basic but functional JSON-dump.